### PR TITLE
Pin llvm-openmp to conda-forge pin (v15)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -35,11 +35,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.10.____cpython.yaml
@@ -8,8 +8,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-llvm_openmp:
-- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.21python3.8.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.8.____73_pypy.yaml
@@ -8,8 +8,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-llvm_openmp:
-- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.8.____cpython.yaml
@@ -8,8 +8,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-llvm_openmp:
-- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.21python3.9.____73_pypy.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.9.____73_pypy.yaml
@@ -8,8 +8,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-llvm_openmp:
-- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.9.____cpython.yaml
@@ -8,8 +8,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-llvm_openmp:
-- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.23python3.11.____cpython.yaml
@@ -8,8 +8,6 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
-llvm_openmp:
-- '15'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - llvm-openmp  # [osx]
+    # Use pinned version: somehow we are ending up with v16
+    - llvm-openmp = 15  # [osx]
     - libgomp      # [linux]
   host:
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     # Use pinned version: somehow we are ending up with v16
-    - llvm-openmp=15  # [osx]
+    - llvm-openmp =15  # [osx]
     - libgomp      # [linux]
   host:
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     # Use pinned version: somehow we are ending up with v16
-    - llvm-openmp = 15  # [osx]
+    - llvm-openmp=15  # [osx]
     - libgomp      # [linux]
   host:
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 4621d962872af8695fcfdf980d319d22477e44d2d19dc0c16365ab548bad571a
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - euphonic-dispersion = euphonic.cli.dispersion:main
     - euphonic-dos = euphonic.cli.dos:main


### PR DESCRIPTION
Not clear why builds are requiring v16 but this doesn't work with packages like Mantid that follow the conda-forge pinned version (15)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
