### PR TITLE
Pin llvm-openmp version for host, not build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 4621d962872af8695fcfdf980d319d22477e44d2d19dc0c16365ab548bad571a
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - euphonic-dispersion = euphonic.cli.dispersion:main
     - euphonic-dos = euphonic.cli.dos:main
@@ -23,10 +23,11 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    # Use pinned version: somehow we are ending up with v16
     - llvm-openmp =15  # [osx]
     - libgomp      # [linux]
   host:
+    # Somehow we are ending up with v16 when pin in build: try requirement here as well
+    - llvm-openmp =15
     - numpy
     - pip
     - python


### PR DESCRIPTION
We are getting some strange requirements in the final package; lvm-openmp appears twice, with minimum versions 15 _and_with minimum version 16.

That's no good for assuring compatibility with Mantid which is pinned to version 15. See if setting in host helps?

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
